### PR TITLE
Added support to add route with already created peering connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ module "vpc-peering" {
   auto_accept_peering     = true
 }
 ```
+
+Usage with already created peering connection:
+```hc1 
+module "vpc-peering" {
+  source = "./terraform-aws-vpc-peering"
+
+  owner_account_id        = "000000000000"
+  vpc_peer_id             = "vpc-00000000"
+  this_vpc_id             = "${module.vpc.vpc_id}"
+  private_route_table_ids = ["${module.vpc.private_route_table_ids}"]
+  public_route_table_ids  = ["${module.vpc.public_route_table_ids}"]
+  peer_cidr_block         = "10.1.0.1/24"
+  auto_accept_peering     = true
+  create_peering          = 0
+  peering_id              = "pcx-00000000"
+
+}
+```
 Examples
 --------
 Complete example is shown above

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "vpc_peering_id" {
   description = "Peering connection ID"
-  value       = "${aws_vpc_peering_connection.this.id}"
+  value       = "${var.peering_id == "" ? element(concat(aws_vpc_peering_connection.this.*.id, list("")), 0) : var.peering_id}"
 }
 
 output "private_route_tables" {

--- a/variables.tf
+++ b/variables.tf
@@ -34,3 +34,13 @@ variable "auto_accept_peering" {
   description = "Auto accept peering connection"
   default     = false
 }
+
+variable "create_peering" {
+  description = "Create peering connection, 0 to not create"
+  default = 1
+}
+
+variable "peering_id" {
+   description = "Provide already existing peering connection id"
+   default = ""
+}


### PR DESCRIPTION
- Added support for propagate routes for already existed peering connection
- Added ability to add routes for more than one public subnet
- Remove `depends_on`, because it redundant here, terraform build it's on dependency.