### PR TITLE
Updated for cross region peering

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,17 +1,21 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_vpc" "this_vpc" {
+  provider      = "aws.this"
   id = "${var.this_vpc_id}"
 }
 
 data "aws_vpc" "peer_vpc" {
+  provider      = "aws.peer"
   id = "${var.peer_vpc_id}"
 }
 
 data "aws_route_tables" "this_vpc_rts" {
+  provider      = "aws.this"
   vpc_id = "${var.this_vpc_id}"
 }
 
 data "aws_route_tables" "peer_vpc_rts" {
+  provider      = "aws.peer"
   vpc_id = "${var.peer_vpc_id}"
 }


### PR DESCRIPTION
I've added some params for cross region peering as I couldn't get it to work.

- Data sources have the region based providers so we can pull the route tables
- The route tables weren't working as they pointed to the normal peering resource.