### PR TITLE
Remove ambiguity for cross-account peering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+Unreleased
+----
+
+* **Breaking change**: variable `owner_account_id` changed to `peer_account_id` for clarity. Please, update your configuration ([#13](https://github.com/grem11n/terraform-aws-vpc-peering/pull/13))
+* Updated README
+* Added CHANGELOG
+
+v1.0.0
+----
+
+* Added cross-region perring ([#11](https://github.com/grem11n/terraform-aws-vpc-peering/pull/11))

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Routes on the Peer VPC side should be configured separately.
 
 This module is designed to work with [VPC](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/) module from the Terraform Registry
 
+Changelog
+----
+Changelog is in the [CHANGELOG.md](CHANGELOG.md)
+
+
 Note
 ----
 
@@ -95,30 +100,15 @@ module "vpc_cross_region_peering" {
 ```
 
 ### Cross Account Peering
-**Notice**: You need to declare both providers even with single region peering.
+In order to make a cross-account peering connection, you must setup both `owner` and `peer` providers accordingly. Also, you have to provide a valid ID of the peer account. Example:
 
 ```hc1
-module "vpc_single_region_peering" {
-  source = "./terraform-aws-vpc-peering"
-
-  providers = {
-    aws.this = "aws"
-    aws.peer = "aws"
-  }
-
-  peer_account_id         = "EEEEEEEEE"
-  peer_region             = "eu-west-1"
-  this_vpc_id             = "vpc-00000000"
-  peer_vpc_id             = "vpc-11111111"
-  cross_region_peering    = false
-  auto_accept_peering     = true
-  create_peering          = true
-
-  tags = {
-    Name        = "my-peering-connection"
-    Environment = "prod"
-  }
+providers = {
+  aws.this = "main" // Alias to the main AWS account
+  aws.peer = "peer" // Alias to the peer AWS account
 }
+
+peer_account_id = "AAABBBCCC1111" // An ID of the peer AWS account
 ```
 
 Examples

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ module "vpc_single_region_peering" {
 ```
 
 Usage with already created peering connection:
-```hc1 
+```hc1
 module "vpc_single_region_peering" {
   source = "./terraform-aws-vpc-peering"
 
@@ -84,6 +84,33 @@ module "vpc_cross_region_peering" {
   this_vpc_id             = "vpc-00000000"
   peer_vpc_id             = "vpc-11111111"
   cross_region_peering    = true
+  auto_accept_peering     = true
+  create_peering          = true
+
+  tags = {
+    Name        = "my-peering-connection"
+    Environment = "prod"
+  }
+}
+```
+
+### Cross Account Peering
+**Notice**: You need to declare both providers even with single region peering.
+
+```hc1
+module "vpc_single_region_peering" {
+  source = "./terraform-aws-vpc-peering"
+
+  providers = {
+    aws.this = "aws"
+    aws.peer = "aws"
+  }
+
+  peer_account_id         = "EEEEEEEEE"
+  peer_region             = "eu-west-1"
+  this_vpc_id             = "vpc-00000000"
+  peer_vpc_id             = "vpc-11111111"
+  cross_region_peering    = false
   auto_accept_peering     = true
   create_peering          = true
 

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
 resource "aws_vpc_peering_connection" "this" {
   provider      = "aws.this"
   count         = "${(var.create_peering * (1 + var.cross_region_peering)) == "1" ? 1 : 0}"
-  peer_owner_id = "${var.owner_account_id == "" ? data.aws_caller_identity.current.account_id : var.owner_account_id}"
+  peer_owner_id = "${var.peer_account_id == "" ? data.aws_caller_identity.current.account_id : var.peer_account_id}"
   peer_vpc_id   = "${var.peer_vpc_id}"
   vpc_id        = "${var.this_vpc_id}"
   auto_accept   = "${var.auto_accept_peering}"
@@ -48,7 +48,7 @@ resource "aws_route" "peer_routes_region" {
 resource "aws_vpc_peering_connection" "this_cross_region" {
   provider      = "aws.this"
   count         = "${(var.create_peering * var.cross_region_peering) == "1" ? 1 : 0}"
-  peer_owner_id = "${var.owner_account_id == "" ? data.aws_caller_identity.current.account_id : var.owner_account_id}"
+  peer_owner_id = "${var.peer_account_id == "" ? data.aws_caller_identity.current.account_id : var.peer_account_id}"
   peer_vpc_id   = "${var.peer_vpc_id}"
   vpc_id        = "${var.this_vpc_id}"
   peer_region   = "${var.peer_region}"

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
-variable "owner_account_id" {
-  description = "AWS owner account ID: string"
+variable "peer_account_id" {
+  description = "AWS owner account ID for Peer VPC. Default to the current account: string"
   default     = ""
 }
 


### PR DESCRIPTION
Transparent declaration of the [`peer_owner_id` variable](https://www.terraform.io/docs/providers/aws/r/vpc_peering.html#peer_owner_id)

Removes ambiguity for cross-account peering connections.

+ README update