### PR TITLE
Don't set peering options for cross-region.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "aws_vpc_peering_connection_options" "this" {
 }
 
 resource "aws_vpc_peering_connection_options" "accepter" {
-  provider = "aws.peer"
+  provider                  = "aws.peer"
   vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer_accepter.id
 
   # See https://github.com/terraform-providers/terraform-provider-aws/issues/6730

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,10 @@ resource "aws_vpc_peering_connection_options" "this" {
   provider                  = "aws.this"
   vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer_accepter.id
 
+  # See https://github.com/terraform-providers/terraform-provider-aws/issues/6730
+  # Until this is fixed, we must not try and set any options for cross-region peering.
+  count = "${data.aws_region.this.name == data.aws_region.peer.name ? 1 : 0}"
+
   requester {
     allow_remote_vpc_dns_resolution  = var.this_dns_resolution
     allow_classic_link_to_remote_vpc = var.this_link_to_peer_classic
@@ -45,8 +49,11 @@ resource "aws_vpc_peering_connection_options" "this" {
 
 resource "aws_vpc_peering_connection_options" "accepter" {
   provider = "aws.peer"
-
   vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer_accepter.id
+
+  # See https://github.com/terraform-providers/terraform-provider-aws/issues/6730
+  # Until this is fixed, we must not try and set any options for cross-region peering.
+  count = "${data.aws_region.this.name == data.aws_region.peer.name ? 1 : 0}"
 
   accepter {
     allow_remote_vpc_dns_resolution  = var.peer_dns_resolution


### PR DESCRIPTION
See https://github.com/terraform-providers/terraform-provider-aws/issues/6730

Until that bug is fixed, setting any options at all for a cross-region
peering setup will simply break.

Which means that the correct thing to do, at the moment, is to set no
options at all.

It's not perfect, but it functions.