### PR TITLE
Tags the same if overlapping resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,10 @@ provider "aws" {
 locals {
   this_region = data.aws_region.this.name
   peer_region = data.aws_region.peer.name
+
+  same_region            = data.aws_region.this.name == data.aws_region.peer.name
+  same_account           = data.aws_caller_identity.this.account_id == data.aws_caller_identity.peer.account_id
+  same_acount_and_region = local.same_region && local.same_account
 }
 
 ##########################
@@ -23,7 +27,7 @@ resource "aws_vpc_peering_connection" "this" {
   peer_vpc_id   = var.peer_vpc_id
   vpc_id        = var.this_vpc_id
   peer_region   = data.aws_region.peer.name
-  tags          = var.tags
+  tags          = merge(var.tags, map("Side", local.same_acount_and_region ? "Both" : "Requester"))
 }
 
 ######################################
@@ -33,7 +37,7 @@ resource "aws_vpc_peering_connection_accepter" "peer_accepter" {
   provider                  = "aws.peer"
   vpc_peering_connection_id = aws_vpc_peering_connection.this.id
   auto_accept               = var.auto_accept_peering
-  tags                      = merge(var.tags, map("Side", "Accepter"))
+  tags                      = merge(var.tags, map("Side", local.same_acount_and_region ? "Both" : "Accepter"))
 }
 
 #######################


### PR DESCRIPTION
If peering between two VPCs in the same account AND region, the aws_vpc_peering_connection_accepter and aws_vpc_peering_connection refer to the same thing.

I tried switching to skip the accepter resource in this case and had to use `coalesce` function everywhere - gave up as looked awful when I was only half way through!

Should supersede #33 and #34 in fixing #32 