### PR TITLE
Deprecate DNS options workaround

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,8 +7,6 @@ provider "aws" {
   alias = "peer"
 }
 
-# Local Values required for inter-region peering workaround
-# See https://github.com/terraform-providers/terraform-provider-aws/issues/6730
 locals {
   this_region = data.aws_region.this.name
   peer_region = data.aws_region.peer.name
@@ -47,10 +45,6 @@ resource "aws_vpc_peering_connection_options" "this" {
   provider                  = "aws.this"
   vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer_accepter.id
 
-  # See https://github.com/terraform-providers/terraform-provider-aws/issues/6730
-  # Until this is fixed, we must not try and set any options for cross-region peering.
-  count = local.this_region == local.peer_region ? 1 : 0
-
   requester {
     allow_remote_vpc_dns_resolution  = var.this_dns_resolution
     allow_classic_link_to_remote_vpc = var.this_link_to_peer_classic
@@ -61,10 +55,6 @@ resource "aws_vpc_peering_connection_options" "this" {
 resource "aws_vpc_peering_connection_options" "accepter" {
   provider                  = "aws.peer"
   vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer_accepter.id
-
-  # See https://github.com/terraform-providers/terraform-provider-aws/issues/6730
-  # Until this is fixed, we must not try and set any options for cross-region peering.
-  count = local.this_region == local.peer_region ? 1 : 0
 
   accepter {
     allow_remote_vpc_dns_resolution  = var.peer_dns_resolution


### PR DESCRIPTION
Deprecate a workaround for setting DNS options since https://github.com/terraform-providers/terraform-provider-aws/issues/6730 is fixed

Fixes https://github.com/grem11n/terraform-aws-vpc-peering/issues/36