### PR TITLE
Deprecate DNS options workaround TF011

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,8 +41,6 @@ resource "aws_vpc_peering_connection_options" "this" {
   provider                  = "aws.this"
   vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer_accepter.id}"
 
-  count = "${data.aws_region.this.name == data.aws_region.peer.name ? 1 : 0}"
-
   requester {
     allow_remote_vpc_dns_resolution  = "${var.this_dns_resolution}"
     allow_classic_link_to_remote_vpc = "${var.this_link_to_peer_classic}"
@@ -54,8 +52,6 @@ resource "aws_vpc_peering_connection_options" "accepter" {
   provider = "aws.peer"
 
   vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer_accepter.id}"
-
-  count = "${data.aws_region.this.name == data.aws_region.peer.name ? 1 : 0}"
 
   accepter {
     allow_remote_vpc_dns_resolution  = "${var.peer_dns_resolution}"


### PR DESCRIPTION
Deprecate a workaround for setting DNS options since https://github.com/terraform-providers/terraform-provider-aws/issues/6730 is fixed

Fixes https://github.com/grem11n/terraform-aws-vpc-peering/issues/36