### PR TITLE
use subnets when peering

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -46,8 +46,8 @@ data "aws_subnet" "peer" {
 
 # get info for only those route tables associated with the given subnets
 data "aws_route_table" "this_subnet_rts" {
-  count = length(var.this_subnets_ids)
-  provider = aws.this
+  count     = length(var.this_subnets_ids)
+  provider  = aws.this
   subnet_id = var.this_subnets_ids[count.index]
 }
 data "aws_route_table" "peer_subnet_rts" {

--- a/data.tf
+++ b/data.tf
@@ -1,10 +1,10 @@
+# Get account and region info
 data "aws_caller_identity" "this" {
   provider = aws.this
 }
 data "aws_region" "this" {
   provider = aws.this
 }
-
 data "aws_caller_identity" "peer" {
   provider = aws.peer
 }
@@ -12,22 +12,46 @@ data "aws_region" "peer" {
   provider = aws.peer
 }
 
+# Get vpc info
 data "aws_vpc" "this_vpc" {
   provider = aws.this
   id       = var.this_vpc_id
 }
-
 data "aws_vpc" "peer_vpc" {
   provider = aws.peer
   id       = var.peer_vpc_id
 }
 
+# Get all route tables from vpcs
 data "aws_route_tables" "this_vpc_rts" {
   provider = aws.this
   vpc_id   = var.this_vpc_id
 }
-
 data "aws_route_tables" "peer_vpc_rts" {
   provider = aws.peer
   vpc_id   = var.peer_vpc_id
+}
+
+# get subnets info
+data "aws_subnet" "this" {
+  count    = length(var.this_subnets_ids)
+  provider = aws.this
+  id       = var.this_subnets_ids[count.index]
+}
+data "aws_subnet" "peer" {
+  count    = length(var.peer_subnets_ids)
+  provider = aws.peer
+  id       = var.peer_subnets_ids[count.index]
+}
+
+# get info for only those route tables associated with the given subnets
+data "aws_route_table" "this_subnet_rts" {
+  count = length(var.this_subnets_ids)
+  provider = aws.this
+  subnet_id = var.this_subnets_ids[count.index]
+}
+data "aws_route_table" "peer_subnet_rts" {
+  count     = length(var.peer_subnets_ids)
+  provider  = aws.peer
+  subnet_id = var.peer_subnets_ids[count.index]
 }

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,33 @@ locals {
   same_region            = data.aws_region.this.name == data.aws_region.peer.name
   same_account           = data.aws_caller_identity.this.account_id == data.aws_caller_identity.peer.account_id
   same_acount_and_region = local.same_region && local.same_account
+
+  // Rout table should either be the one for the vpc, or the ones associated to the subnets if subnets are given
+  this_rts_ids_new = data.aws_route_tables.this_vpc_rts.ids
+  peer_rts_ids_new = data.aws_route_tables.peer_vpc_rts.ids
+
+  this_rts_ids = length(var.this_subnets_ids) == 0 ? local.this_rts_ids_new : data.aws_route_table.this_subnet_rts[*].route_table_id
+  peer_rts_ids = length(var.peer_subnets_ids) == 0 ? local.peer_rts_ids_new : data.aws_route_table.peer_subnet_rts[*].route_table_id
+
+  // Destination cidrs for this are in peer and vice versa
+  this_dest_cidrs = length(var.peer_subnets_ids) == 0 ? toset([data.aws_vpc.peer_vpc.cidr_block]) : toset(data.aws_subnet.peer[*].cidr_block)
+  peer_dest_cidrs = length(var.this_subnets_ids) == 0 ? toset([data.aws_vpc.this_vpc.cidr_block]) : toset(data.aws_subnet.this[*].cidr_block)
+
+  // In each route table there should be 1 route for each subnet, so combining the two sets
+  this_routes = [
+    for pair in setproduct(local.this_rts_ids, local.this_dest_cidrs) : {
+      rts_id    = pair[0]
+      dest_cidr = pair[1]
+    }
+  ]
+
+  // In each route table there should be 1 route for each subnet, so combining the two sets
+  peer_routes = [
+    for pair in setproduct(local.peer_rts_ids, local.peer_dest_cidrs) : {
+      rts_id    = pair[0]
+      dest_cidr = pair[1]
+    }
+  ]
 }
 
 ##########################
@@ -64,23 +91,25 @@ resource "aws_vpc_peering_connection_options" "accepter" {
 }
 
 ###################
-# This VPC Routes #
+# This VPC Routes #  Route from THIS route table to PEER cidr
 ###################
-resource "aws_route" "this_routes_region" {
+resource "aws_route" "this_routes" {
   provider                  = aws.this
-  count                     = length(data.aws_route_tables.this_vpc_rts.ids)
-  route_table_id            = tolist(data.aws_route_tables.this_vpc_rts.ids)[count.index]
-  destination_cidr_block    = data.aws_vpc.peer_vpc.cidr_block
+  # Only create routes in this route table if input allows, and in that case for all combinations
+  count                     = var.from_this ? length(local.this_routes) : 0
+  route_table_id            = local.this_routes[count.index].rts_id
+  destination_cidr_block    = local.this_routes[count.index].dest_cidr
   vpc_peering_connection_id = aws_vpc_peering_connection.this.id
 }
 
 ###################
-# Peer VPC Routes #
+# Peer VPC Routes #  Route from PEER route table to THIS cidr
 ###################
-resource "aws_route" "peer_routes_region" {
+resource "aws_route" "peer_routes" {
   provider                  = aws.peer
-  count                     = length(data.aws_route_tables.peer_vpc_rts.ids)
-  route_table_id            = tolist(data.aws_route_tables.peer_vpc_rts.ids)[count.index]
-  destination_cidr_block    = data.aws_vpc.this_vpc.cidr_block
+  # Only create routes in this route table if input allows, and in that case for all combinations
+  count                     = var.from_peer ? length(local.peer_routes) : 0
+  route_table_id            = local.peer_routes[count.index].rts_id
+  destination_cidr_block    = local.peer_routes[count.index].dest_cidr
   vpc_peering_connection_id = aws_vpc_peering_connection.this.id
 }

--- a/main.tf
+++ b/main.tf
@@ -15,18 +15,18 @@ locals {
   same_account           = data.aws_caller_identity.this.account_id == data.aws_caller_identity.peer.account_id
   same_acount_and_region = local.same_region && local.same_account
 
-  // Rout table should either be the one for the vpc, or the ones associated to the subnets if subnets are given
+  # Rout table should either be the one for the vpc, or the ones associated to the subnets if subnets are given
   this_rts_ids_new = data.aws_route_tables.this_vpc_rts.ids
   peer_rts_ids_new = data.aws_route_tables.peer_vpc_rts.ids
 
   this_rts_ids = length(var.this_subnets_ids) == 0 ? local.this_rts_ids_new : data.aws_route_table.this_subnet_rts[*].route_table_id
   peer_rts_ids = length(var.peer_subnets_ids) == 0 ? local.peer_rts_ids_new : data.aws_route_table.peer_subnet_rts[*].route_table_id
 
-  // Destination cidrs for this are in peer and vice versa
+  # Destination cidrs for this are in peer and vice versa
   this_dest_cidrs = length(var.peer_subnets_ids) == 0 ? toset([data.aws_vpc.peer_vpc.cidr_block]) : toset(data.aws_subnet.peer[*].cidr_block)
   peer_dest_cidrs = length(var.this_subnets_ids) == 0 ? toset([data.aws_vpc.this_vpc.cidr_block]) : toset(data.aws_subnet.this[*].cidr_block)
 
-  // In each route table there should be 1 route for each subnet, so combining the two sets
+  # In each route table there should be 1 route for each subnet, so combining the two sets
   this_routes = [
     for pair in setproduct(local.this_rts_ids, local.this_dest_cidrs) : {
       rts_id    = pair[0]
@@ -34,7 +34,7 @@ locals {
     }
   ]
 
-  // In each route table there should be 1 route for each subnet, so combining the two sets
+  # In each route table there should be 1 route for each subnet, so combining the two sets
   peer_routes = [
     for pair in setproduct(local.peer_rts_ids, local.peer_dest_cidrs) : {
       rts_id    = pair[0]
@@ -94,8 +94,8 @@ resource "aws_vpc_peering_connection_options" "accepter" {
 # This VPC Routes #  Route from THIS route table to PEER cidr
 ###################
 resource "aws_route" "this_routes" {
-  provider                  = aws.this
-  # Only create routes in this route table if input allows, and in that case for all combinations
+  provider = aws.this
+  # Only create routes for this route table if input dictates it, and in that case, for all combinations
   count                     = var.from_this ? length(local.this_routes) : 0
   route_table_id            = local.this_routes[count.index].rts_id
   destination_cidr_block    = local.this_routes[count.index].dest_cidr
@@ -106,8 +106,8 @@ resource "aws_route" "this_routes" {
 # Peer VPC Routes #  Route from PEER route table to THIS cidr
 ###################
 resource "aws_route" "peer_routes" {
-  provider                  = aws.peer
-  # Only create routes in this route table if input allows, and in that case for all combinations
+  provider = aws.peer
+  # Only create routes for peer route table if input dictates it, and in that case, for all combinations
   count                     = var.from_peer ? length(local.peer_routes) : 0
   route_table_id            = local.peer_routes[count.index].rts_id
   destination_cidr_block    = local.peer_routes[count.index].dest_cidr

--- a/outputs.tf
+++ b/outputs.tf
@@ -58,5 +58,5 @@ output "requester_routes" {
 
 output "accepter_routes" {
   description = "Routes to the accepter VPC"
-  value = tolist(aws_route.peer_routes.*)
+  value       = tolist(aws_route.peer_routes.*)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,8 +1,3 @@
-locals {
-  this_vpc_route_tables = data.aws_route_tables.this_vpc_rts.ids
-  peer_vpc_route_tables = data.aws_route_tables.peer_vpc_rts.ids
-}
-
 output "aws_vpc_peering_connection" {
   value = aws_vpc_peering_connection.this
 }
@@ -10,7 +5,6 @@ output "aws_vpc_peering_connection" {
 output "aws_vpc_peering_connection_accepter" {
   value = aws_vpc_peering_connection_accepter.peer_accepter
 }
-
 
 output "vpc_peering_id" {
   description = "Peering connection ID"
@@ -57,12 +51,12 @@ output "requester_options" {
   value       = aws_vpc_peering_connection_accepter.peer_accepter.requester
 }
 
-output "this_vpc_route_tables" {
-  description = "Private route tables"
-  value       = tolist(data.aws_route_tables.this_vpc_rts.ids)
+output "requester_routes" {
+  description = "Routes from the requester VPC"
+  value       = tolist(aws_route.this_routes.*)
 }
 
-output "peer_vpc_route_table" {
-  description = "Public route tables"
-  value       = tolist(data.aws_route_tables.peer_vpc_rts.ids)
+output "accepter_routes" {
+  description = "Routes to the accepter VPC"
+  value = tolist(aws_route.peer_routes.*)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,18 @@
 variable "peer_vpc_id" {
   description = "Peer VPC ID: string"
+  type        = string
   default     = ""
 }
 
 variable "this_vpc_id" {
   description = "This VPC ID: string"
+  type        = string
   default     = ""
 }
 
 variable "auto_accept_peering" {
   description = "Auto accept peering connection: bool"
+  type        = bool
   default     = false
 }
 
@@ -21,30 +24,60 @@ variable "tags" {
 
 variable "peer_dns_resolution" {
   description = "Indicates whether a local VPC can resolve public DNS hostnames to private IP addresses when queried from instances in a peer VPC"
+  type        = bool
   default     = false
 }
 
 variable "peer_link_to_peer_classic" {
   description = "Indicates whether a local ClassicLink connection can communicate with the peer VPC over the VPC Peering Connection"
+  type        = bool
   default     = false
 }
 
 variable "peer_link_to_local_classic" {
   description = "Indicates whether a local VPC can communicate with a ClassicLink connection in the peer VPC over the VPC Peering Connection"
+  type        = bool
   default     = false
 }
 
 variable "this_dns_resolution" {
   description = "Indicates whether a local VPC can resolve public DNS hostnames to private IP addresses when queried from instances in a this VPC"
+  type        = bool
   default     = false
 }
 
 variable "this_link_to_peer_classic" {
   description = "Indicates whether a local ClassicLink connection can communicate with the this VPC over the VPC Peering Connection"
+  type        = bool
   default     = false
 }
 
 variable "this_link_to_local_classic" {
   description = "Indicates whether a local VPC can communicate with a ClassicLink connection in the this VPC over the VPC Peering Connection"
+  type        = bool
   default     = false
+}
+
+variable "from_this" {
+  description = "If traffic TO peer vpc (from this) should be allowed"
+  type        = bool
+  default     = true
+}
+
+variable "from_peer" {
+  description = "If traffic FROM peer vpc (to this) should be allowed"
+  type        = bool
+  default     = true
+}
+
+variable "peer_subnets_ids" {
+  description = "If communication can only go to some specific subnets of peer vpc. If empty whole vpc cidr is allowed"
+  type        = list(string)
+  default     = []
+}
+
+variable "this_subnets_ids" {
+  description = "If communication can only go to some specific subnets of this vpc. If empty whole vpc cidr is allowed"
+  type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
I have added possibility for setting specific subnets when peering, for both this and peer vpc.
Since we want this feature in our peering, (and cross account) and this was the mpt fitting module I could find =)

However I have tot been able to run the terratests at all localy, and have not done an example yet either. But can do so.

This is a draft PR so far for discussions around this =)