### PR TITLE
Adding flag to enable or disable the creation of the VPC Peering.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -48,3 +48,8 @@ variable "this_link_to_local_classic" {
   description = "Indicates whether a local VPC can communicate with a ClassicLink connection in the this VPC over the VPC Peering Connection"
   default     = false
 }
+
+variable "create_vpc_peering" {
+  description = "A flag to enable or disable the creation of the VPC peering."
+  default     = true
+}


### PR DESCRIPTION
Under certain conditions this feature is needed so different VPC peerings can be
created with the same code in different environments.

For example when development is done in one region and in the other environments there are more than one regional deployments _from different source vpcs to one target vpc_. In this situation (and other similar situations) this flags allows for the conditional creation of peer connections depending on the environment of deployment.