### PR TITLE
Move from map to tomap.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "aws_vpc_peering_connection" "this" {
   peer_vpc_id   = var.peer_vpc_id
   vpc_id        = var.this_vpc_id
   peer_region   = data.aws_region.peer.name
-  tags          = merge(var.tags, tomap({"Side" = local.same_acount_and_region ? "Both" : "Requester"}))
+  tags          = merge(var.tags, tomap({ "Side" = local.same_acount_and_region ? "Both" : "Requester" }))
 }
 
 ######################################
@@ -17,7 +17,7 @@ resource "aws_vpc_peering_connection_accepter" "peer_accepter" {
   provider                  = aws.peer
   vpc_peering_connection_id = aws_vpc_peering_connection.this.id
   auto_accept               = var.auto_accept_peering
-  tags                      = merge(var.tags, tomap({"Side" = local.same_acount_and_region ? "Both" : "Accepter"}))
+  tags                      = merge(var.tags, tomap({ "Side" = local.same_acount_and_region ? "Both" : "Accepter" }))
 }
 
 #######################

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "aws_vpc_peering_connection" "this" {
   peer_vpc_id   = var.peer_vpc_id
   vpc_id        = var.this_vpc_id
   peer_region   = data.aws_region.peer.name
-  tags          = merge(var.tags, map("Side", local.same_acount_and_region ? "Both" : "Requester"))
+  tags          = merge(var.tags, tomap({"Side" = local.same_acount_and_region ? "Both" : "Requester"}))
 }
 
 ######################################
@@ -17,7 +17,7 @@ resource "aws_vpc_peering_connection_accepter" "peer_accepter" {
   provider                  = aws.peer
   vpc_peering_connection_id = aws_vpc_peering_connection.this.id
   auto_accept               = var.auto_accept_peering
-  tags                      = merge(var.tags, map("Side", local.same_acount_and_region ? "Both" : "Accepter"))
+  tags                      = merge(var.tags, tomap({"Side" = local.same_acount_and_region ? "Both" : "Accepter"}))
 }
 
 #######################


### PR DESCRIPTION
This is required for support of terraform v0.15.

With this, stuff works, though we are getting warnings about the empty provider blocks.

I can fix that warning, but doing so makes terraform validate fail messily inside the module itself, I suspect that this is a terraform v0.15.0 bug, but that's going to have to be a matter for another day.