### PR TITLE
Allow newer aws provider versions

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~> 3.37"
+      version               = ">= 3.37"
       configuration_aliases = [aws.this, aws.peer]
     }
   }


### PR DESCRIPTION
Most terraform modules seem to use optimistic provider version constraint, would it work here too?

Solves https://github.com/grem11n/terraform-aws-vpc-peering/issues/85