### PR TITLE
fix(example-readme): Cross account, single region

### DIFF
--- a/examples/multi-account-multi-region/README.md
+++ b/examples/multi-account-multi-region/README.md
@@ -1,6 +1,7 @@
 # Cross Account Multi Region VPC Peering
 
 This example creates a peering connection between VPCs in different regions which are also located in different AWS accounts.
+See [provider.tf](provider.tf) for more details.
 
 ## Sample Code
 

--- a/examples/multi-account-single-region/README.md
+++ b/examples/multi-account-single-region/README.md
@@ -1,6 +1,7 @@
-# Cross Account Multi Region VPC Peering
+# Cross Account Single Region VPC Peering
 
-This example creates a peering connection between VPCs in different regions which are also located in different AWS accounts.
+This example creates a peering connection between VPCs in a single region which are located in different AWS accounts.
+See [provider.tf](provider.tf) for details.
 
 ## Sample Code
 


### PR DESCRIPTION
# Description
It seems the readme was copied/pasted from another example and not properly updated.