### PR TITLE
[Deprecation] Remove EC2 Classic

### DIFF
--- a/examples/single-account-single-region-with-options/README.md
+++ b/examples/single-account-single-region-with-options/README.md
@@ -5,7 +5,7 @@
 Configuration in this directory creates a peering connection between VPCs in a single region within the same AWS account. It also creates connection options:
 
 * Cross-VPC DNS resolution option
-* Allow classic link access between VPCs
+* [Deprecated] Allow classic link access between VPCs
 
 ## Code Sample
 
@@ -29,13 +29,9 @@ module "single_account_single_region_options" {
 
   // Peering options for requester
   this_dns_resolution        = true
-  this_link_to_peer_classic  = true
-  this_link_to_local_classic = true
 
   // Peering options for accepter
   peer_dns_resolution        = true
-  peer_link_to_peer_classic  = true
-  peer_link_to_local_classic = true
 
   tags = {
     Name        = "tf-single-account-single-region-with-options"

--- a/examples/single-account-single-region-with-options/main.tf
+++ b/examples/single-account-single-region-with-options/main.tf
@@ -15,13 +15,9 @@ module "single_account_single_region_options" {
 
   // Peering options for requester
   this_dns_resolution        = true
-  this_link_to_peer_classic  = true
-  this_link_to_local_classic = true
 
   // Peering options for accepter
   peer_dns_resolution        = true
-  peer_link_to_peer_classic  = true
-  peer_link_to_local_classic = true
 
   tags = {
     Name        = "tf-single-account-single-region-with-options"

--- a/main.tf
+++ b/main.tf
@@ -33,9 +33,7 @@ resource "aws_vpc_peering_connection_options" "this" {
   vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer_accepter.id
 
   requester {
-    allow_remote_vpc_dns_resolution  = var.this_dns_resolution
-    allow_classic_link_to_remote_vpc = var.this_link_to_peer_classic
-    allow_vpc_to_remote_classic_link = var.this_link_to_local_classic
+    allow_remote_vpc_dns_resolution = var.this_dns_resolution
   }
 }
 
@@ -44,9 +42,7 @@ resource "aws_vpc_peering_connection_options" "accepter" {
   vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer_accepter.id
 
   accepter {
-    allow_remote_vpc_dns_resolution  = var.peer_dns_resolution
-    allow_classic_link_to_remote_vpc = var.peer_link_to_peer_classic
-    allow_vpc_to_remote_classic_link = var.peer_link_to_local_classic
+    allow_remote_vpc_dns_resolution = var.peer_dns_resolution
   }
 }
 

--- a/test/fixtures/single-account-single-region-with-options/main.tf
+++ b/test/fixtures/single-account-single-region-with-options/main.tf
@@ -2,8 +2,6 @@
 // VPCs
 resource "aws_vpc" "this" {
   cidr_block           = "172.20.0.0/16"
-  enable_classiclink   = true
-  enable_dns_support   = true
   enable_dns_hostnames = true
 
   tags = {
@@ -14,8 +12,6 @@ resource "aws_vpc" "this" {
 
 resource "aws_vpc" "peer" {
   cidr_block           = "172.21.0.0/16"
-  enable_classiclink   = true
-  enable_dns_support   = true
   enable_dns_hostnames = true
 
   tags = {

--- a/variables.tf
+++ b/variables.tf
@@ -28,32 +28,8 @@ variable "peer_dns_resolution" {
   default     = false
 }
 
-variable "peer_link_to_peer_classic" {
-  description = "Indicates whether a local ClassicLink connection can communicate with the peer VPC over the VPC Peering Connection"
-  type        = bool
-  default     = false
-}
-
-variable "peer_link_to_local_classic" {
-  description = "Indicates whether a local VPC can communicate with a ClassicLink connection in the peer VPC over the VPC Peering Connection"
-  type        = bool
-  default     = false
-}
-
 variable "this_dns_resolution" {
   description = "Indicates whether a local VPC can resolve public DNS hostnames to private IP addresses when queried from instances in a this VPC"
-  type        = bool
-  default     = false
-}
-
-variable "this_link_to_peer_classic" {
-  description = "Indicates whether a local ClassicLink connection can communicate with the this VPC over the VPC Peering Connection"
-  type        = bool
-  default     = false
-}
-
-variable "this_link_to_local_classic" {
-  description = "Indicates whether a local VPC can communicate with a ClassicLink connection in the this VPC over the VPC Peering Connection"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
AWS EC2 Classic has been retired and Classic Link config in VPC Peering Connections have been deprecated and will be removed in a future version of the AWS provider.

Closes #91 