### PR TITLE
Update AWS provider version

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~> 5"
+      version               = ">= 5"
       configuration_aliases = [aws.this, aws.peer]
     }
   }

--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 5"
+      version               = ">= 4"
       configuration_aliases = [aws.this, aws.peer]
     }
   }

--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~> 4"
+      version               = "~> 5"
       configuration_aliases = [aws.this, aws.peer]
     }
   }


### PR DESCRIPTION
Due to the update of this [module](https://github.com/terraform-aws-modules/terraform-aws-vpc), it is not possible to use the current one with it due to an unupdated provider.