### PR TITLE
Allow to define the peering connection name as a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,31 @@ module "single_account_single_region" {
 }
 ```
 
+You can also define the peering name as a variable:
+
+
+```hcl
+module "single_account_single_region" {
+  source = "../../"
+
+  providers = {
+    aws.this = aws
+    aws.peer = aws
+  }
+
+  name = "tf-single-account-single-region"
+
+  this_vpc_id = var.this_vpc_id
+  peer_vpc_id = var.peer_vpc_id
+
+  auto_accept_peering = true
+
+  tags = {
+    Environment = "Test"
+  }
+}
+```
+
 ## Changelog
 
 See the changelog on [the GitHub Releases page](https://github.com/grem11n/terraform-aws-vpc-peering/releases).

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "aws_vpc_peering_connection" "this" {
   peer_vpc_id   = var.peer_vpc_id
   vpc_id        = var.this_vpc_id
   peer_region   = data.aws_region.peer.name
-  tags          = merge(var.tags, tomap({ "Side" = local.same_acount_and_region ? "Both" : "Requester" }))
+  tags          = merge(var.tags, { "Name" = var.name }, tomap({ "Side" = local.same_acount_and_region ? "Both" : "Requester" }))
   # hardcoded
   timeouts {
     create = "15m"
@@ -22,7 +22,7 @@ resource "aws_vpc_peering_connection_accepter" "peer_accepter" {
   provider                  = aws.peer
   vpc_peering_connection_id = aws_vpc_peering_connection.this.id
   auto_accept               = var.auto_accept_peering
-  tags                      = merge(var.tags, tomap({ "Side" = local.same_acount_and_region ? "Both" : "Accepter" }))
+  tags                      = merge(var.tags, { "Name" = var.name }, tomap({ "Side" = local.same_acount_and_region ? "Both" : "Accepter" }))
 }
 
 #######################

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "auto_accept_peering" {
   default     = false
 }
 
+variable "name" {
+  description = "Name of the peering connection: string"
+  type        = string
+  default     = ""
+}
+
 variable "tags" {
   description = "Tags: map"
   type        = map(string)


### PR DESCRIPTION
This PR allows to define a resource name in a standard way, as a variable.

![image](https://github.com/grem11n/terraform-aws-vpc-peering/assets/15939365/71599c99-a978-4431-b982-f9e49f7ca9c2)

You can use other tags as before. 

Name as a variable has a precedence over name as a tag, so if you by mistake declare both, the former is going to be used.