### PR TITLE
Run tests in parallel

### DIFF
--- a/examples/custom-name-tag/main.tf
+++ b/examples/custom-name-tag/main.tf
@@ -1,6 +1,6 @@
 // Basic Module Example
 // Creates a peering between VPCs in the same account in the same region
-module "custiom_name" {
+module "custom_name" {
   source = "../../"
 
   providers = {

--- a/examples/custom-name-tag/outputs.tf
+++ b/examples/custom-name-tag/outputs.tf
@@ -1,8 +1,8 @@
 // Required for tests
 output "vpc_peering_accept_status" {
-  value = module.custiom_name.vpc_peering_accept_status
+  value = module.custom_name.vpc_peering_accept_status
 }
 
 output "vpc_peering_connection" {
-  value = module.custiom_name.aws_vpc_peering_connection
+  value = module.custom_name.aws_vpc_peering_connection
 }

--- a/test/fixtures/custom-name/main.tf
+++ b/test/fixtures/custom-name/main.tf
@@ -1,0 +1,65 @@
+// Fixtures
+// VPCs
+resource "aws_vpc" "this" {
+  cidr_block = "172.22.0.0/16"
+
+  tags = {
+    Name        = "this_vpc"
+    Environment = "Test"
+  }
+}
+
+resource "aws_vpc" "peer" {
+  cidr_block = "172.23.0.0/16"
+
+  tags = {
+    Name        = "peer_vpc"
+    Environment = "Test"
+  }
+}
+
+// Route Tables
+resource "aws_route_table" "this" {
+  count  = length(var.this_subnets)
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name        = "This VPC RT"
+    Environment = "Test"
+  }
+}
+
+resource "aws_route_table" "peer" {
+  count  = length(var.peer_subnets)
+  vpc_id = aws_vpc.peer.id
+
+  tags = {
+    Name        = "Peer VPC RT"
+    Environment = "Test"
+  }
+}
+
+// Subnets
+resource "aws_subnet" "this" {
+  count             = length(var.this_subnets)
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.this_subnets[count.index]
+  availability_zone = element(var.azs, count.index)
+
+  tags = {
+    Name        = "This VPC Subnet"
+    Environment = "Test"
+  }
+}
+
+resource "aws_subnet" "peer" {
+  count             = length(var.peer_subnets)
+  vpc_id            = aws_vpc.peer.id
+  cidr_block        = var.peer_subnets[count.index]
+  availability_zone = element(var.azs, count.index)
+
+  tags = {
+    Name        = "This VPC Subnet"
+    Environment = "Test"
+  }
+}

--- a/test/fixtures/custom-name/outputs.tf
+++ b/test/fixtures/custom-name/outputs.tf
@@ -1,0 +1,7 @@
+output "this_vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "peer_vpc_id" {
+  value = aws_vpc.peer.id
+}

--- a/test/fixtures/custom-name/provider.tf
+++ b/test/fixtures/custom-name/provider.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  endpoints {
+    ec2 = "http://localhost:4566"
+    s3  = "http://localhost:4566"
+    sts = "http://localhost:4566"
+  }
+  region                      = "eu-west-1"
+  access_key                  = "null"
+  secret_key                  = "null"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+}

--- a/test/fixtures/custom-name/variables.tf
+++ b/test/fixtures/custom-name/variables.tf
@@ -1,0 +1,17 @@
+variable "this_subnets" {
+  description = "Subnet list for _this_ VPC"
+  type        = list(string)
+  default     = ["172.22.0.0/24", "172.22.1.0/24", "172.22.2.0/24"]
+}
+
+variable "peer_subnets" {
+  description = "Subnet list for _peer_ VPC"
+  type        = list(string)
+  default     = ["172.23.0.0/24", "172.23.1.0/24", "172.23.2.0/24"]
+}
+
+variable "azs" {
+  description = "Availability Zones"
+  type        = list(string)
+  default     = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+}

--- a/test/fixtures/default-name/main.tf
+++ b/test/fixtures/default-name/main.tf
@@ -1,0 +1,65 @@
+// Fixtures
+// VPCs
+resource "aws_vpc" "this" {
+  cidr_block = "172.24.0.0/16"
+
+  tags = {
+    Name        = "this_vpc"
+    Environment = "Test"
+  }
+}
+
+resource "aws_vpc" "peer" {
+  cidr_block = "172.25.0.0/16"
+
+  tags = {
+    Name        = "peer_vpc"
+    Environment = "Test"
+  }
+}
+
+// Route Tables
+resource "aws_route_table" "this" {
+  count  = length(var.this_subnets)
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name        = "This VPC RT"
+    Environment = "Test"
+  }
+}
+
+resource "aws_route_table" "peer" {
+  count  = length(var.peer_subnets)
+  vpc_id = aws_vpc.peer.id
+
+  tags = {
+    Name        = "Peer VPC RT"
+    Environment = "Test"
+  }
+}
+
+// Subnets
+resource "aws_subnet" "this" {
+  count             = length(var.this_subnets)
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.this_subnets[count.index]
+  availability_zone = element(var.azs, count.index)
+
+  tags = {
+    Name        = "This VPC Subnet"
+    Environment = "Test"
+  }
+}
+
+resource "aws_subnet" "peer" {
+  count             = length(var.peer_subnets)
+  vpc_id            = aws_vpc.peer.id
+  cidr_block        = var.peer_subnets[count.index]
+  availability_zone = element(var.azs, count.index)
+
+  tags = {
+    Name        = "This VPC Subnet"
+    Environment = "Test"
+  }
+}

--- a/test/fixtures/default-name/outputs.tf
+++ b/test/fixtures/default-name/outputs.tf
@@ -1,0 +1,7 @@
+output "this_vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "peer_vpc_id" {
+  value = aws_vpc.peer.id
+}

--- a/test/fixtures/default-name/provider.tf
+++ b/test/fixtures/default-name/provider.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  endpoints {
+    ec2 = "http://localhost:4566"
+    s3  = "http://localhost:4566"
+    sts = "http://localhost:4566"
+  }
+  region                      = "eu-west-1"
+  access_key                  = "null"
+  secret_key                  = "null"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+}

--- a/test/fixtures/default-name/variables.tf
+++ b/test/fixtures/default-name/variables.tf
@@ -1,0 +1,17 @@
+variable "this_subnets" {
+  description = "Subnet list for _this_ VPC"
+  type        = list(string)
+  default     = ["172.24.0.0/24", "172.24.1.0/24", "172.24.2.0/24"]
+}
+
+variable "peer_subnets" {
+  description = "Subnet list for _peer_ VPC"
+  type        = list(string)
+  default     = ["172.25.0.0/24", "172.25.1.0/24", "172.25.2.0/24"]
+}
+
+variable "azs" {
+  description = "Availability Zones"
+  type        = list(string)
+  default     = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+}


### PR DESCRIPTION
To speed up things.

Separate fixtures are required because we use the same Localstack environment for all the tests, thus we need new VPCs.