### PR TITLE
Require AWS provider >= 6

### DIFF
--- a/.github/workflows/terratest.yml
+++ b/.github/workflows/terratest.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        terraform: ['1.5.7', '1.12.2']
+        terraform: ['1.5.7', '1.13.0']
     steps:
       -  uses: actions/checkout@master
       -  uses: hashicorp/setup-terraform@v1
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        terraform: ['1.5.7', '1.12.2']
+        terraform: ['1.5.7', '1.13.0']
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 4"
+      version               = ">= 6"
       configuration_aliases = [aws.this, aws.peer]
     }
   }


### PR DESCRIPTION
The change from https://github.com/grem11n/terraform-aws-vpc-peering/pull/123 requires AWS provider `>= 6.0.0`